### PR TITLE
Updates buildah `image push` step

### DIFF
--- a/clusterBuildStrategy/source-to-image/README.md
+++ b/clusterBuildStrategy/source-to-image/README.md
@@ -6,7 +6,7 @@ The `source-to-image` ClusterBuildStrategy is composed of [source-to-image](http
 ## Install the Strategy
 
 ```
-$ oc apply -f https://raw.githubusercontent.com/redhat-developer/openshift-builds-catalog/main/clusterBuildStrategy/buildah/source_to_image.yaml
+$ oc apply -f https://raw.githubusercontent.com/redhat-developer/openshift-builds-catalog/main/clusterBuildStrategy/source-to-image/source_to_image.yaml
 ```
 
 ## Usage

--- a/clusterBuildStrategy/source-to-image/source_to_image.yaml
+++ b/clusterBuildStrategy/source-to-image/source_to_image.yaml
@@ -115,11 +115,12 @@ spec:
             --registries-conf=/tmp/registries.conf \
             --tag="${image}"
 
-          # Write the image
-          echo "[INFO] Writing image ${image}"
+          # Push the image
+          echo "[INFO] Pushing image ${image}"
           buildah --storage-driver=$(params.storage-driver) push \
+            --digestfile='$(results.shp-image-digest.path)' \
             "${image}" \
-            "oci:${target}"
+            "docker://${image}"
         # That's the separator between the shell script and its args
         - --
         - --image
@@ -130,8 +131,6 @@ spec:
         - $(params.registries-insecure[*])
         - --registries-search
         - $(params.registries-search[*])
-        - --target
-        - $(params.shp-output-directory)
       volumeMounts:
         - name: s2i
           mountPath: /s2i


### PR DESCRIPTION
`buildah` step in the source-to-image CBS no longer writes the image, but pushes the image directly to the output repo (spec.output.image). 
This eliminates the requirement of `image-processing` step, and hence the need for `DAC_OVERRIDE`.