### PR TITLE
Use official images in build strategies

### DIFF
--- a/clusterBuildStrategy/buildah/README.md
+++ b/clusterBuildStrategy/buildah/README.md
@@ -1,5 +1,8 @@
 # Buildah ClusterBuildStrategy
-The `buildah` ClusterBuildStrategy uses [buildah](https://github.com/containers/buildah) to build and push a container image, out of a `Dockerfile`. The `Dockerfile` should be specified using a parameter in the `Build` resource.
+
+The `buildah` ClusterBuildStrategy uses [buildah](https://github.com/containers/buildah) to build
+and push a container image, out of a `Dockerfile` or `Containerfile`. The `Dockerfile` should be
+specified using the `dockerfile` parameter in the `Build` resource.
 
 ## Install the Strategy
 
@@ -8,7 +11,10 @@ $ oc apply -f https://raw.githubusercontent.com/redhat-developer/openshift-build
 ```
 
 ## Usage
-This Build uses buildah strategy to build an image using a Dockerfile, and pushes the built image to OpenShift's internal registry (`output.image`).
+
+This example uses the buildah strategy to build an image using a Dockerfile, and pushes the image
+to OpenShift's internal registry (`output.image`). The following example assumes the OpenShift
+internal registry is enabled and the `BuildRun` executes in the `buildah-sample` namespace:
 
 ```yaml
 apiVersion: shipwright.io/v1beta1

--- a/clusterBuildStrategy/buildah/buildah.yaml
+++ b/clusterBuildStrategy/buildah/buildah.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: quay.io/containers/buildah:v1.32.0
+      image: registry.redhat.io/ubi8/buildah:8.8
       workingDir: $(params.shp-source-root)
       securityContext:
         capabilities:

--- a/clusterBuildStrategy/source-to-image/README.md
+++ b/clusterBuildStrategy/source-to-image/README.md
@@ -1,7 +1,11 @@
 # Source-To-Image (S2I) ClusterBuildStrategy
-The `source-to-image` ClusterBuildStrategy is composed of [source-to-image](https://github.com/openshift/source-to-image/) and [buildah](https://github.com/containers/buildah) in order to generate a `Dockerfile` and prepare the application to be built later with a builder-image.
 
-`s2i` requires a specially crafted image, which can be informed as `builder-image` parameter on the `Build` resource.
+The `source-to-image` ClusterBuildStrategy allows source code to be compiled and packaged into a
+container image using the [source-to-image](https://github.com/openshift/source-to-image) tool.
+Its functionality is similar to the `Source` build strategy using
+[OpenShift BuildConfigs](https://docs.openshift.com/container-platform/latest/cicd/builds/build-strategies.html#builds-strategy-s2i-build_build-strategies-docker)
+
+Developers must provide an s2i-enabled builder image as the base image, using the `builder-image` parameter.
 
 ## Install the Strategy
 
@@ -10,7 +14,13 @@ $ oc apply -f https://raw.githubusercontent.com/redhat-developer/openshift-build
 ```
 
 ## Usage
-This Build uses source-to-image-redhat strategy to build an image, and pushes the built image to a quay repository (`output.image`).
+
+This example uses the source-to-image strategy to build an image, and pushes the built image to a quay repository (`output.image`).
+It assumes the following:
+
+- The Samples Operator is enabled and installed the default OpenShift ImageStreams.
+- `<my-repo>` is a quay.io user or organization repository, and that the secret
+  `registry-credential` contains credentials that allow the build to push images to the repository.
 
 ```yaml
 apiVersion: shipwright.io/v1beta1
@@ -27,12 +37,12 @@ spec:
     kind: ClusterBuildStrategy
   paramValues:
   - name: builder-image
-    value: "quay.io/centos7/nodejs-12-centos7"
+    value: image-registry.openshift-image-registry.svc:5000/openshift/nodejs:16-ubi9
   - name: registries-block
     values:
     - value: docker.io 
   output:
-    image: quay.io/repo/s2i-nodejs-example
+    image: quay.io/<my-repo>/s2i-nodejs-example
     pushSecret: registry-credential
 ```
 

--- a/clusterBuildStrategy/source-to-image/README.md
+++ b/clusterBuildStrategy/source-to-image/README.md
@@ -19,7 +19,7 @@ This example uses the source-to-image strategy to build an image, and pushes the
 It assumes the following:
 
 - The Samples Operator is enabled and installed the default OpenShift ImageStreams.
-- `<my-repo>` is a quay.io user or organization repository, and that the secret
+- `<my-repo>` is a quay.io user or organization repository, and the secret
   `registry-credential` contains credentials that allow the build to push images to the repository.
 
 ```yaml

--- a/clusterBuildStrategy/source-to-image/source_to_image.yaml
+++ b/clusterBuildStrategy/source-to-image/source_to_image.yaml
@@ -9,7 +9,7 @@ spec:
       emptyDir: {}
   buildSteps:
     - name: s2i-generate
-      image: registry.redhat.io/ocp-tools-43-tech-preview/source-to-image-rhel8:latest
+      image: registry.redhat.io/source-to-image/source-to-image-rhel8:v1.3.9
       workingDir: $(params.shp-source-root)
       command: 
         - /usr/local/bin/s2i
@@ -23,7 +23,7 @@ spec:
         - name: s2i
           mountPath: /s2i
     - name: buildah
-      image: quay.io/containers/buildah:v1.32.0
+      image: registry.redhat.io/ubi8/buildah:8.8
       workingDir: /s2i
       securityContext:
         capabilities:


### PR DESCRIPTION
Update image references to use the Red Hat Container Catalog

- Buildah: use registry.redhat.io/ubi8/buildah
- s2i: use our GA image registry.redhat.io/source-to-image/source-to-image-rhel8

Documentation was also updated to clarify how the build strategies work.