### PR TITLE
update: remove duplicate output image in buildpacks example

### DIFF
--- a/clusterBuildStrategy/buildpacks/README.md
+++ b/clusterBuildStrategy/buildpacks/README.md
@@ -31,8 +31,6 @@ spec:
       value: paketocommunity/run-ubi-base:latest
     - name: cnb-builder-image
       value: paketobuildpacks/builder-jammy-tiny:0.0.176
-    - name: app-image
-      value: image-registry.openshift-image-registry.svc:5000/buildpacks-example/taxi-app
   output:
     image: image-registry.openshift-image-registry.svc:5000/buildpacks-example/taxi-app
 ```
@@ -42,8 +40,7 @@ spec:
 | ------------------ | ------ | ----------------------------------------------------- | --------------------------------------------- |
 | cnb-platform-api   | string | Platform API Version supported                        | "0.12"                                        |
 | cnb-builder-image  | string | Builder image containing the buildpacks               | ""                                            |
-| cnb-lifecycle-image | string | Image to use when executing Lifecycle phases          | "docker.io/buildpacksio/lifecycle:0.17.0"      |
-| app-image          | string | Name of where to store the app image                   | N/A                                           |
+| cnb-lifecycle-image | string | Image to use when executing Lifecycle phases          | "docker.io/buildpacksio/lifecycle:0.17.0"      |                                          |
 | run-image          | string | Reference to a run image to use                        | ""                                            |
 | cache-image        | string | Name of the persistent app cache image                 | ""                                            |
 | cache-dir-name     | string | Directory to cache files                               | "cache"                                       |

--- a/clusterBuildStrategy/buildpacks/buildpacks.yaml
+++ b/clusterBuildStrategy/buildpacks/buildpacks.yaml
@@ -21,8 +21,6 @@ spec:
     - name: cnb-lifecycle-image
       description: The image to use when executing Lifecycle phases.
       default: "docker.io/buildpacksio/lifecycle:0.17.0"
-    - name: app-image
-      description: The name of where to store the app image.
     - name: run-image
       description: Reference to a run image to use.
       default: ""
@@ -131,7 +129,7 @@ spec:
         - "-cache-image=$(params.cache-image)"
         - "-uid=$(params.user-id)"
         - "-gid=$(params.group-id)"
-        - "$(params.app-image)"
+        - "$(params.shp-output-image)"
       env:
         - name: CNB_PLATFORM_API
           value: $(params.cnb-platform-api)
@@ -213,7 +211,7 @@ spec:
         - "-process-type=$(params.process-type)"
         - "-uid=$(params.user-id)"
         - "-gid=$(params.group-id)"
-        - "$(params.app-image)"
+        - "$(params.shp-output-image)"
       env:
         - name: CNB_PLATFORM_API
           value: $(params.cnb-platform-api)


### PR DESCRIPTION
Removing the app-image parameter in buildpacks example to remove duplicacy.