### PR TITLE
fix: updating Build CR example in Readme to change the source subpath to nodejs

### DIFF
--- a/clusterBuildStrategy/buildpacks/README.md
+++ b/clusterBuildStrategy/buildpacks/README.md
@@ -33,7 +33,7 @@ spec:
     - name: cnb-builder-image
       value: paketobuildpacks/builder-jammy-tiny:0.0.344
     - name: source-subpath
-      value: "buildpacks"
+      value: "buildpacks/nodejs"
   output:
     image: image-registry.openshift-image-registry.svc:5000/buildpacks-example/taxi-app
 ```


### PR DESCRIPTION
The source subpath has been changed in the samples repository and the referenced nodejs app path has been changed. The path has been updated in this PR