### PR TITLE
update: use ubi9 images for strategies

### DIFF
--- a/clusterBuildStrategy/buildah/buildah.yaml
+++ b/clusterBuildStrategy/buildah/buildah.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   steps:
     - name: build-and-push
-      image: registry.redhat.io/ubi8/buildah:8.10-9
+      image: registry.redhat.io/ubi9/buildah@sha256:4a267751427aa3a4df3e66a789f034446b3fb274b882572f22ad99106f87fdb7
       imagePullPolicy: Always
       workingDir: $(params.shp-source-root)
       securityContext:

--- a/clusterBuildStrategy/buildpacks-extender/buildpacks-extender.yaml
+++ b/clusterBuildStrategy/buildpacks-extender/buildpacks-extender.yaml
@@ -65,7 +65,7 @@ spec:
       default: "/layers/extended"
   steps:
     - name: prepare
-      image: registry.access.redhat.com/ubi8/ubi:8.8-1067.1698056881
+      image: registry.access.redhat.com/ubi9/ubi@sha256:2e4eebec441e8bbc3459fcc83ddee0f7d3cfd219097b4110a37d7ff4fe0ff2e9
       args:
         - -c
         - |
@@ -308,7 +308,7 @@ spec:
         - name: empty-dir
           mountPath: /platform
     - name: results
-      image: registry.access.redhat.com/ubi8/ubi:8.8-1067.1698056881
+      image: registry.access.redhat.com/ubi9/ubi@sha256:2e4eebec441e8bbc3459fcc83ddee0f7d3cfd219097b4110a37d7ff4fe0ff2e9
       args:
         - -c
         - |

--- a/clusterBuildStrategy/buildpacks/buildpacks.yaml
+++ b/clusterBuildStrategy/buildpacks/buildpacks.yaml
@@ -65,7 +65,7 @@ spec:
       default: "/layers/extended"
   steps:
     - name: prepare
-      image: registry.access.redhat.com/ubi8/ubi:8.8-1067.1698056881
+      image: registry.access.redhat.com/ubi9/ubi@sha256:2e4eebec441e8bbc3459fcc83ddee0f7d3cfd219097b4110a37d7ff4fe0ff2e9
       args:
         - -c
         - |
@@ -278,7 +278,7 @@ spec:
         - name: empty-dir
           mountPath: /platform
     - name: results
-      image: registry.access.redhat.com/ubi8/ubi:8.8-1067.1698056881
+      image: registry.access.redhat.com/ubi9/ubi@sha256:2e4eebec441e8bbc3459fcc83ddee0f7d3cfd219097b4110a37d7ff4fe0ff2e9
       args:
         - -c
         - |

--- a/clusterBuildStrategy/source-to-image/source-to-image.yaml
+++ b/clusterBuildStrategy/source-to-image/source-to-image.yaml
@@ -12,7 +12,7 @@ spec:
       overridable: true
   buildSteps:
     - name: s2i-generate
-      image: registry.redhat.io/source-to-image/source-to-image-rhel8:1.4.1
+      image: registry.redhat.io/source-to-image/source-to-image-rhel9@sha256:70293cb8a80aa548933ff5f502bac89945a5cd08801c4ca3aac08a10dd01f62f
       workingDir: $(params.shp-source-root)
       command: 
         - /usr/local/bin/s2i
@@ -28,7 +28,7 @@ spec:
         - name: etc-pki-entitlement
           mountPath: /etc/pki/entitlement
     - name: buildah
-      image: registry.redhat.io/ubi8/buildah:8.10-9
+      image: registry.redhat.io/ubi9/buildah@sha256:4a267751427aa3a4df3e66a789f034446b3fb274b882572f22ad99106f87fdb7
       workingDir: /s2i
       securityContext:
         capabilities:


### PR DESCRIPTION
- update source-to-image, buildah and buildpack to ubi9 based images

Signed-off-by: Avinal Kumar <avinal@redhat.com>
