### PR TITLE
[BUILD-1578] feat: add no-cache parameter to buildah ClusterBuildStrategy

### DIFF
--- a/clusterBuildStrategy/buildah/buildah.yaml
+++ b/clusterBuildStrategy/buildah/buildah.yaml
@@ -26,6 +26,7 @@ spec:
           image=
           budArgs=()
           inBuildArgs=false
+          noCache="false"
           registriesBlock=""
           inRegistriesBlock=false
           registriesInsecure=""
@@ -57,6 +58,13 @@ spec:
               inRegistriesInsecure=false
               inRegistriesSearch=false
               image="$1"
+              shift
+            elif [ "${arg}" == "--no-cache" ]; then
+              inBuildArgs=false
+              inRegistriesBlock=false
+              inRegistriesInsecure=false
+              inRegistriesSearch=false
+              noCache="$1"
               shift
             elif [ "${arg}" == "--target" ]; then
               inBuildArgs=false
@@ -146,6 +154,10 @@ spec:
           EOF
           fi
 
+          if [ "${noCache}" == "true" ]; then
+            budArgs+=("--no-cache")
+          fi
+
           # Building the image
           echo "[INFO] Building image ${image}"
           buildah --storage-driver=$(params.storage-driver) \
@@ -180,6 +192,8 @@ spec:
         - $(params.registries-search[*])
         - --target
         - $(params.target)
+        - --no-cache
+        - $(params.no-cache)
       volumeMounts:
         - mountPath: /etc/pki/entitlement
           name: etc-pki-entitlement
@@ -222,6 +236,10 @@ spec:
       description: "Sets the target stage to be built."
       type: string
       default: ""
+    - name: no-cache
+      description: "Do not use existing cached images for the container build. Build from the start with a new set of cached layers."
+      type: string
+      default: "false"
   volumes:
     - name: etc-pki-entitlement
       emptyDir: {}


### PR DESCRIPTION
This PR
- adds support for the no-cache parameter to the buildah ClusterBuildStrategy.
- fixes BUILD-1578

Operator PR for reference - https://github.com/redhat-openshift-builds/operator/pull/1367

Co-Authored-By: Claude Code