### PR TITLE
[BUILD-1746] feat: add runtime-stage-from parameter to buildah ClusterBuildStrategy

### DIFF
--- a/clusterBuildStrategy/buildah/buildah.yaml
+++ b/clusterBuildStrategy/buildah/buildah.yaml
@@ -24,6 +24,7 @@ spec:
           context=
           dockerfile=
           image=
+          runtimeStageFrom=
           budArgs=()
           inBuildArgs=false
           noCache="false"
@@ -65,6 +66,13 @@ spec:
               inRegistriesInsecure=false
               inRegistriesSearch=false
               noCache="$1"
+              shift
+            elif [ "${arg}" == "--runtime-stage-from" ]; then
+              inBuildArgs=false
+              inRegistriesBlock=false
+              inRegistriesInsecure=false
+              inRegistriesSearch=false
+              runtimeStageFrom="$1"
               shift
             elif [ "${arg}" == "--target" ]; then
               inBuildArgs=false
@@ -158,6 +166,14 @@ spec:
             budArgs+=("--no-cache")
           fi
 
+          if [ -n "${runtimeStageFrom}" ]; then
+            lastFromImage=$(tac "${dockerfile}" | grep -m1 -i -E '^[ ]*FROM' | \
+              sed -n '0,/p/s/^[ ]*from[ ]\+\([^ ]*\)[ ]*\(as.*$\)\{0,1\}$/\1/Ip')
+            if [ -n "${lastFromImage}" ]; then
+              budArgs+=("--build-context" "${lastFromImage}=docker-image://${runtimeStageFrom}")
+            fi
+          fi
+
           # Building the image
           echo "[INFO] Building image ${image}"
           buildah --storage-driver=$(params.storage-driver) \
@@ -194,6 +210,8 @@ spec:
         - $(params.target)
         - --no-cache
         - $(params.no-cache)
+        - --runtime-stage-from
+        - $(params.runtime-stage-from)
       volumeMounts:
         - mountPath: /etc/pki/entitlement
           name: etc-pki-entitlement
@@ -223,6 +241,10 @@ spec:
       defaults:
         - registry.redhat.io
         - quay.io
+    - name: runtime-stage-from
+      description: "Image name used to replace the value in the last FROM instruction in the Dockerfile."
+      type: string
+      default: ""
     - name: dockerfile
       description: The path to the Dockerfile to be used for building the image.
       type: string


### PR DESCRIPTION
This PR
- adds support for the runtime-stage-from parameter to the buildah ClusterBuildStrategy.
- fixes BUILD-1746

Operator PR for reference - https://github.com/redhat-openshift-builds/operator/pull/1383

Co-Authored-By: Claude Code