### PR TITLE
[BUILD-2342] Add overridable trusted-ca volume to buildah and source-to-image strategies

### DIFF
--- a/clusterBuildStrategy/buildah/buildah.yaml
+++ b/clusterBuildStrategy/buildah/buildah.yaml
@@ -20,6 +20,22 @@ spec:
         - |
           set -euo pipefail
 
+          # Import additional trusted CA certificates supplied through the
+          # trusted-ca volume (e.g. a ConfigMap holding a PEM bundle) into the
+          # system trust store, so that image pulls and pushes trust endpoints
+          # signed by a custom/private CA. No-op when the volume is empty.
+          trustedCADir=/var/shipwright/trusted-ca
+          if [ -d "${trustedCADir}" ]; then
+            certs=$(find -L "${trustedCADir}" -maxdepth 1 -type f \( -name '*.crt' -o -name '*.pem' \) 2>/dev/null || true)
+            if [ -n "${certs}" ]; then
+              echo "[INFO] Importing trusted CA certificates from ${trustedCADir}"
+              while IFS= read -r cert; do
+                cp -L "${cert}" /etc/pki/ca-trust/source/anchors/
+              done <<< "${certs}"
+              update-ca-trust extract
+            fi
+          fi
+
           # Parse parameters
           context=
           dockerfile=
@@ -243,6 +259,9 @@ spec:
       volumeMounts:
         - mountPath: /etc/pki/entitlement
           name: etc-pki-entitlement
+        - mountPath: /var/shipwright/trusted-ca
+          name: trusted-ca
+          readOnly: true
       resources:
         limits:
           cpu: "1"
@@ -300,6 +319,9 @@ spec:
       default: "false"
   volumes:
     - name: etc-pki-entitlement
+      emptyDir: {}
+      overridable: true
+    - name: trusted-ca
       emptyDir: {}
       overridable: true
   securityContext:

--- a/clusterBuildStrategy/source-to-image/source-to-image.yaml
+++ b/clusterBuildStrategy/source-to-image/source-to-image.yaml
@@ -10,6 +10,9 @@ spec:
     - name: etc-pki-entitlement
       emptyDir: {}
       overridable: true
+    - name: trusted-ca
+      emptyDir: {}
+      overridable: true
   steps:
     - name: s2i-generate
       image: registry.redhat.io/source-to-image/source-to-image-rhel9@sha256:798e0e860df8e3ca1ff5f8aa796940d6dbd4b739ccfc35c6f4c9bc046d5f0c12
@@ -75,6 +78,22 @@ spec:
         - -c
         - |
           set -euo pipefail
+
+          # Import additional trusted CA certificates supplied through the
+          # trusted-ca volume (e.g. a ConfigMap holding a PEM bundle) into the
+          # system trust store, so that image pulls and pushes trust endpoints
+          # signed by a custom/private CA. No-op when the volume is empty.
+          trustedCADir=/var/shipwright/trusted-ca
+          if [ -d "${trustedCADir}" ]; then
+            certs=$(find -L "${trustedCADir}" -maxdepth 1 -type f \( -name '*.crt' -o -name '*.pem' \) 2>/dev/null || true)
+            if [ -n "${certs}" ]; then
+              echo "[INFO] Importing trusted CA certificates from ${trustedCADir}"
+              while IFS= read -r cert; do
+                cp -L "${cert}" /etc/pki/ca-trust/source/anchors/
+              done <<< "${certs}"
+              update-ca-trust extract
+            fi
+          fi
 
           # Parse parameters
           image=
@@ -175,6 +194,9 @@ spec:
           mountPath: /s2i
         - name: etc-pki-entitlement
           mountPath: /etc/pki/entitlement
+        - name: trusted-ca
+          mountPath: /var/shipwright/trusted-ca
+          readOnly: true
   parameters:
     - name: build-env
       description: "Environment variables to set during the build and in the output image. Values must be in the format KEY=VALUE."


### PR DESCRIPTION
## Summary
Adds an `overridable: true` `trusted-ca` ConfigMap volume to the shipped `buildah` and `source-to-image` ClusterBuildStrategies, mounted at `/var/shipwright/trusted-ca` in the build step. This lets a Build override the volume with its own CA ConfigMap so builds can pull/push against registries signed by a private CA — without touching the operator-injected cluster-wide trusted CA bundle (`config-trusted-cabundle` at `/tekton-custom-certs`), which is unchanged and coexists with this volume.

Jira: [BUILD-2342](https://issues.redhat.com/browse/BUILD-2342) (spun out of [BUILD-2329](https://issues.redhat.com/browse/BUILD-2329))

## Test evidence (real cluster, OpenShift Builds operator v1.4)
- Applied updated `ClusterBuildStrategy` + Build overriding `trusted-ca` with ConfigMap `my-trusted-ca` (`ca-bundle.crt` → `tls-ca-bundle.pem`)
- Build validation: `registered=True, reason=Succeeded, all validations succeeded`
- BuildRun completed: `Succeeded — All Steps have completed executing`
- TaskRun pod shows both volumes mounted:
  - `trusted-ca` (user ConfigMap) at `/var/shipwright/trusted-ca` in `step-build-and-push`
  - operator's `config-trusted-cabundle-volume` at `/tekton-custom-certs/ca-bundle.crt` (unchanged)

## Note for reviewers
Existing Builds referencing an edited strategy do not re-validate on strategy update (Build controller reconciles on generation change only) — a Build spec change or recreate is needed to pick up the new volume definition. Worth keeping in mind for docs/QE steps.
